### PR TITLE
Fix completion of "sysd systemctl" and don't run "service".

### DIFF
--- a/sysd
+++ b/sysd
@@ -25,17 +25,9 @@ die() {
 ACTION=$1
 shift
 
-run_systemctl() {
-  if [ -x /usr/bin/systemctl ]; then
-    systemctl $*
-  else
-    /usr/sbin/service $2 $1
-  fi
-}
-
 case $ACTION in
   help) man sysd ;;
-  s|systemctl) run_systemctl $* ;;
+  s|systemctl) systemctl $* ;;
   bootctl) bootctl $* ;;
   h|hostnamectl) hostnamectl $* ;;
   j|journalctl) journalctl $* ;;

--- a/sysd-completion-bash
+++ b/sysd-completion-bash
@@ -22,7 +22,7 @@ _sysd() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   commands="bootctl hostnamectl journalctl localectl loginctl machinectl
-  timedatectl analyze ask-password cat cgls cgtop coredumpctl delta
+  systemctl timedatectl analyze ask-password cat cgls cgtop coredumpctl delta
   detect-virt inhibit machine-id-setup notify nspawn run stdio-bridge tmpfiles
   tty-ask-password-agent lscg topcg"
 


### PR DESCRIPTION
On an Ubuntu/Debian system, the run_systemctl() function didn't work correctly, and I found it pretty surprising that sysd was quietly deciding to run "service" instead of "systemctl". Maybe I'm not seeing the use case for this, but I think sysd is better without it.